### PR TITLE
Fixed a small typo

### DIFF
--- a/src/content/en/fundamentals/performance/rendering/optimize-javascript-execution.markdown
+++ b/src/content/en/fundamentals/performance/rendering/optimize-javascript-execution.markdown
@@ -127,7 +127,7 @@ Armed with this information you can assess the performance impact of the JavaScr
 
 ## Avoid micro-optimizing your JavaScript
 
-It may be cool to know that the browser can execute one version of a thing 100 times faster than another thing, like that requesting and element’s `offsetTop` is faster than computing `getBoundingClientRect()`, but it’s almost always true that you’ll only be calling functions like these a small number of times per frame, so it’s normally wasted effort to focus on this aspect of JavaScript’s performance. You'll typically only save fractions of milliseconds.
+It may be cool to know that the browser can execute one version of a thing 100 times faster than another thing, like that requesting an element’s `offsetTop` is faster than computing `getBoundingClientRect()`, but it’s almost always true that you’ll only be calling functions like these a small number of times per frame, so it’s normally wasted effort to focus on this aspect of JavaScript’s performance. You'll typically only save fractions of milliseconds.
 
 If you’re making a game, or a computationally expensive application, then you’re likely an exception to this guidance, as you’ll be typically fitting a lot of computation into a single frame, and in that case everything helps.
 


### PR DESCRIPTION
Fixed a small typo changed an `and` to `an`.

Result :-
- Before :- 
  
  > It may be cool to know that the browser can execute one version of a thing 100 times faster               than another thing, like that requesting `and` element’s offsetTop is faster than computing getBoundingClientRect().
- After :- 
  
  > It may be cool to know that the browser can execute one version of a thing 100 times faster than another thing, like that requesting `an` element’s offsetTop is faster than computing getBoundingClientRect() 
